### PR TITLE
[fix] Update blocked list

### DIFF
--- a/src/blocked.ts
+++ b/src/blocked.ts
@@ -31,7 +31,20 @@ const blocked = [
     "tickets to kendrick lamar",
     "my carolina football tickets",
     "duke basketball game tickets",
-    "duke football game tickets"
+    "duke football game tickets",
+    "duke football tickets",
+    "duke basketball tickets",
+    "duke tickets",
+    "carolina football tickets",
+    "carolina football game tickets",
+    "carolina basketball tickets",
+    "carolina basketball game tickets",
+    "tyler the creator tickets",
+    "tyler the creator concert tickets",
+    "kendrick lamar tickets",
+    "kendrick lamar concert tickets",
+    "free ps5",
+    "free ps5 giveaway",
 ];
 
 export default blocked;


### PR DESCRIPTION
This pull request expands the list of blocked phrases in the `src/blocked.ts` file to cover more ticket-related and giveaway queries, improving filtering for unwanted content.

Blocked phrases list expanded:

* Added multiple new phrases related to Duke and Carolina sports tickets, including both football and basketball games.
* Included additional phrases for popular concert tickets, such as "tyler the creator" and "kendrick lamar".
* Added phrases targeting "free ps5" and "free ps5 giveaway" to block common giveaway spam.