### PR TITLE
[fix] add terms from recent bots

### DIFF
--- a/src/blocked.ts
+++ b/src/blocked.ts
@@ -53,6 +53,16 @@ const blocked = [
     "text me for help with classes",
     "contact me for help with classes",
     "contact me for help with online classes",
+    "billie eilish",
+    "sabrina carpenter",
+    "tate mcrae",
+    "fetzer",
+    "ps5",
+    "playstation 5",
+    "season tickets",
+    "season pass",
+    "full season",
+    "full pass",
 ];
 
 export default blocked;


### PR DESCRIPTION
This pull request adds several new terms to the `blocked` list in `src/blocked.ts` to enhance content moderation and filtering. The newly blocked terms include names of popular artists and entertainment-related keywords.

Content moderation updates:

* Added "billie eilish", "sabrina carpenter", and "tate mcrae" to the blocked terms list to prevent mentions of these popular artists.
* Added "fetzer", "ps5", "playstation 5", "season tickets", "season pass", "full season", and "full pass" to block references to specific venues, gaming consoles, and ticketing phrases.