### PR TITLE
[fix] update to reflect recent bots

### DIFF
--- a/src/blocked.ts
+++ b/src/blocked.ts
@@ -53,6 +53,20 @@ const blocked = [
     "text me for help with classes",
     "contact me for help with classes",
     "contact me for help with online classes",
+    "i'll do your classwork for you",
+    "billie eilish tickets",
+    "sabrina carpenter tickets",
+    "tate mcrae tickets",
+    "free macbook",
+    "free macbook air",
+    "free macbook pro",
+    "giveaway macbook",
+    "giveaway macbook air",
+    "giveaway macbook pro",
+    "selling macbook",
+    "selling macbook air",
+    "selling macbook pro",
+    "sell macbook",
 ];
 
 export default blocked;


### PR DESCRIPTION
This pull request adds several new phrases to the `blocked` list in `src/blocked.ts` to enhance the filtering of inappropriate or spam content. The main focus is on expanding coverage for classwork offers, ticket sales, and MacBook-related giveaways or sales.

Blocked phrase list expansion:

* Added phrases related to offering to do classwork, such as `"i'll do your classwork for you"`.
* Included phrases targeting ticket sales for popular artists, including `"billie eilish tickets"`, `"sabrina carpenter tickets"`, and `"tate mcrae tickets"`.
* Added multiple phrases related to MacBook giveaways and sales, such as `"free macbook"`, `"giveaway macbook pro"`, and `"selling macbook air"`.