### PR TITLE
Add action to prevent accidental merges to main

### DIFF
--- a/.github/workflows/branch-protection.yml
+++ b/.github/workflows/branch-protection.yml
@@ -1,0 +1,17 @@
+name: Main Branch Protection
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  check-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check branch
+        run: |
+          if [[ ${GITHUB_HEAD_REF} != staging ]] && ! [[ ${GITHUB_HEAD_REF} =~ ^hotfix/ ]]; then
+            echo "Error: Pull requests to main must come from 'staging' or 'hotfix/' branch"
+            exit 1
+          fi


### PR DESCRIPTION
Because the intended flow is feature branch -> staging -> main, it is important that commits don't skip the staging branch. Since main is the default branch, PRs can sometimes end up directed at main and cause git history issues. This action should flag that as an issue and prevent merge.