### PR TITLE
Issue #56 Fix: Check for webhook secret

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,8 +7,8 @@ const app = new Hono<{ Bindings: Env }>();
 app.post("/webhook/:secret", async (c: Context) => {
 	const provided_secret = c.req.param("secret");
 
-	if (provided_secret !== c.env.WEBHOOK_SECRET){
-		return c.json({error: "Unauthorized"}, 401)
+	if (provided_secret !== c.env.WEBHOOK_SECRET) {
+		return c.json({ error: "Unauthorized" }, 401);
 	}
 	return groupMeWebhookHandler(c);
 });


### PR DESCRIPTION
Update callback url in GroupMe to reflect the updated path. Generate a secret with **openssl rand -32**.