### PR TITLE
Add notifications for invalid tokens

### DIFF
--- a/src/.env.example
+++ b/src/.env.example
@@ -1,0 +1,10 @@
+# Required
+GROUPME_ACCESS_TOKEN=
+GROUPME_BOT_ID=
+WEBHOOK_SECRET=
+
+# If set, error notifications will be sent via this bot ID
+GROUPME_BOT_ID_ERROR_ALERTS=
+
+# (dev) Toggles staging behavior
+STAGING=

--- a/src/webhook-handler.ts
+++ b/src/webhook-handler.ts
@@ -55,50 +55,69 @@ export async function groupMeWebhookHandler(c: Context) {
 			return;
 		}
 
-		const { text: groupRaw } = await safeFetch(
-			`https://api.groupme.com/v3/groups/${group_id}?token=${token}`,
-			undefined,
-			"Get Group Data",
-		);
-		const groupData = JSON.parse(groupRaw);
-
-		type GroupMember = { user_id: string; id: string };
-		const member = groupData.response.members.find(
-			(m: GroupMember) => m.user_id === sender_user_id,
-		);
-		if (!member) {
-			console.warn(`User ${sender_user_id} not found in group ${group_id}`);
-			return c.json({ status: "user not found" }, 200);
-		}
-		const membership_id = member.id;
-
-		await safeFetch(
-			`https://api.groupme.com/v3/conversations/${group_id}/messages/${message_id}?token=${token}`,
-			{ method: "DELETE" },
-			"Delete Message",
-		);
-
-		await safeFetch(
-			`https://api.groupme.com/v3/groups/${group_id}/members/${membership_id}/remove?token=${token}`,
-			{ method: "POST" },
-			"Remove User",
-		);
-
-		await safeFetch(
-			`https://api.groupme.com/v3/groups/${group_id}/members/${membership_id}/remove?token=${token}`,
-			{ method: "POST" },
-			"Remove User",
-		);
-
-		if (Math.floor(Math.random() * 1000000) === 462926) {
-			await safeFetch(
-				`https://api.groupme.com/v3/bots/post`,
-				{
-					method: "POST",
-					body: JSON.stringify({ bot_id, text: "BOTS BEGONE 🤬" }),
-				},
-				"Post Bot Message",
+		try {
+			const { text: groupRaw } = await safeFetch(
+				`https://api.groupme.com/v3/groups/${group_id}?token=${token}`,
+				undefined,
+				"Get Group Data",
 			);
+			const groupData = JSON.parse(groupRaw);
+
+			type GroupMember = { user_id: string; id: string };
+			const member = groupData.response.members.find(
+				(m: GroupMember) => m.user_id === sender_user_id,
+			);
+			if (!member) {
+				console.warn(`User ${sender_user_id} not found in group ${group_id}`);
+				return c.json({ status: "user not found" }, 200);
+			}
+			const membership_id = member.id;
+
+			await safeFetch(
+				`https://api.groupme.com/v3/conversations/${group_id}/messages/${message_id}?token=${token}`,
+				{ method: "DELETE" },
+				"Delete Message",
+			);
+
+			await safeFetch(
+				`https://api.groupme.com/v3/groups/${group_id}/members/${membership_id}/remove?token=${token}`,
+				{ method: "POST" },
+				"Remove User",
+			);
+
+			await safeFetch(
+				`https://api.groupme.com/v3/groups/${group_id}/members/${membership_id}/remove?token=${token}`,
+				{ method: "POST" },
+				"Remove User",
+			);
+
+			if (Math.floor(Math.random() * 1000000) === 462926) {
+				await safeFetch(
+					`https://api.groupme.com/v3/bots/post`,
+					{
+						method: "POST",
+						body: JSON.stringify({ bot_id, text: "BOTS BEGONE 🤬" }),
+					},
+					"Post Bot Message",
+				);
+			}
+		} catch (err) {
+			console.warn("General error handling blocked content", err);
+			if (c.env.GROUPME_BOT_ID_ERROR_ALERTS) {
+				await safeFetch(
+					`https://api.groupme.com/v3/bots/post`,
+					{
+						method: "POST",
+						body: JSON.stringify({
+							bot_id: c.env.GROUPME_BOT_ID_ERROR_ALERTS,
+							text: "⚠️ Error occurred in production! Check access token validity in CF environment variables.",
+						}),
+					},
+					"Post Bot Message",
+				);
+			}
+			
+			throw err;
 		}
 	} else {
 		console.log("Message passed moderation check.");

--- a/src/webhook-handler.ts
+++ b/src/webhook-handler.ts
@@ -116,7 +116,7 @@ export async function groupMeWebhookHandler(c: Context) {
 					"Post Bot Message",
 				);
 			}
-			
+
 			throw err;
 		}
 	} else {

--- a/src/webhook-handler.ts
+++ b/src/webhook-handler.ts
@@ -13,18 +13,8 @@ export function isIllegalMessage(message: string): boolean {
 
 async function safeFetch(url: string, options?: RequestInit, label?: string) {
 	try {
-		console.log(
-			`[HTTP] Request${label ? ` - ${label}` : ""}:`,
-			url,
-			options || {},
-		);
 		const res = await fetch(url, options);
 		const text = await res.text();
-		console.log(
-			`[HTTP] Response${label ? ` - ${label}` : ""}:`,
-			res.status,
-			text,
-		);
 		return { res, text };
 	} catch (err) {
 		console.error(`[HTTP] Error${label ? ` - ${label}` : ""}:`, err);
@@ -34,7 +24,6 @@ async function safeFetch(url: string, options?: RequestInit, label?: string) {
 
 export async function groupMeWebhookHandler(c: Context) {
 	const body = await c.req.json();
-	console.log("Incoming webhook:", JSON.stringify(body));
 
 	const text = (body.text || "").toLowerCase();
 	const group_id = body.group_id;
@@ -66,13 +55,13 @@ export async function groupMeWebhookHandler(c: Context) {
 			return;
 		}
 
-		console.log("Fetching group data to resolve membership_id...");
 		const { text: groupRaw } = await safeFetch(
 			`https://api.groupme.com/v3/groups/${group_id}?token=${token}`,
 			undefined,
 			"Get Group Data",
 		);
 		const groupData = JSON.parse(groupRaw);
+
 		type GroupMember = { user_id: string; id: string };
 		const member = groupData.response.members.find(
 			(m: GroupMember) => m.user_id === sender_user_id,
@@ -82,9 +71,6 @@ export async function groupMeWebhookHandler(c: Context) {
 			return c.json({ status: "user not found" }, 200);
 		}
 		const membership_id = member.id;
-		console.log(
-			`Resolved membership_id for user ${sender_user_id}: ${membership_id}`,
-		);
 
 		await safeFetch(
 			`https://api.groupme.com/v3/conversations/${group_id}/messages/${message_id}?token=${token}`,

--- a/src/webhook-handler.ts
+++ b/src/webhook-handler.ts
@@ -15,6 +15,7 @@ async function safeFetch(url: string, options?: RequestInit, label?: string) {
 	try {
 		const res = await fetch(url, options);
 		const text = await res.text();
+		if (!res.ok) throw new Error(`HTTP ${res.status} - ${text}`);
 		return { res, text };
 	} catch (err) {
 		console.error(`[HTTP] Error${label ? ` - ${label}` : ""}:`, err);

--- a/test/webhook-handler.test.ts
+++ b/test/webhook-handler.test.ts
@@ -599,7 +599,7 @@ describe("groupMeWebhookHandler", () => {
 
 		test("should not notify when error alert env var is not set", async () => {
 			if (mockContext.env) {
-				delete (mockContext.env as any).GROUPME_BOT_ID_ERROR_ALERTS;
+				delete mockContext.env.GROUPME_BOT_ID_ERROR_ALERTS;
 			}
 
 			(mockContext.req?.json as jest.Mock)?.mockResolvedValue({

--- a/test/webhook-handler.test.ts
+++ b/test/webhook-handler.test.ts
@@ -258,7 +258,7 @@ describe("groupMeWebhookHandler", () => {
 
 			await groupMeWebhookHandler(mockContext as Context);
 
-			expect(mockFetch).toHaveBeenCalledTimes(4);
+			expect(mockFetch).toHaveBeenCalledTimes(3);
 
 			expect(mockFetch).toHaveBeenNthCalledWith(
 				1,
@@ -274,12 +274,6 @@ describe("groupMeWebhookHandler", () => {
 
 			expect(mockFetch).toHaveBeenNthCalledWith(
 				3,
-				"https://api.groupme.com/v3/groups/12345/members/membership_001/remove?token=test_token",
-				{ method: "POST" },
-			);
-
-			expect(mockFetch).toHaveBeenNthCalledWith(
-				4,
 				"https://api.groupme.com/v3/groups/12345/members/membership_001/remove?token=test_token",
 				{ method: "POST" },
 			);
@@ -381,7 +375,7 @@ describe("groupMeWebhookHandler", () => {
 
 			await groupMeWebhookHandler(mockContext as Context);
 
-			expect(mockFetch).toHaveBeenCalledTimes(4);
+			expect(mockFetch).toHaveBeenCalledTimes(3);
 			expect(mockContext.json).toHaveBeenCalledWith({ status: "ok" }, 200);
 		});
 
@@ -412,7 +406,7 @@ describe("groupMeWebhookHandler", () => {
 
 			await groupMeWebhookHandler(mockContext as Context);
 
-			expect(mockFetch).toHaveBeenCalledTimes(4);
+			expect(mockFetch).toHaveBeenCalledTimes(3);
 			expect(mockContext.json).toHaveBeenCalledWith({ status: "ok" }, 200);
 		});
 	});
@@ -491,10 +485,10 @@ describe("groupMeWebhookHandler", () => {
 
 			await groupMeWebhookHandler(mockContext as Context);
 
-			expect(mockFetch).toHaveBeenCalledTimes(5);
+			expect(mockFetch).toHaveBeenCalledTimes(4);
 
 			expect(mockFetch).toHaveBeenNthCalledWith(
-				5,
+				4,
 				"https://api.groupme.com/v3/bots/post",
 				expect.objectContaining({
 					method: "POST",


### PR DESCRIPTION
Addresses #53 

If `safeFetch` fails (usually due to an invalid GroupMe user token), an error notification will be posted via the bot token provided as `GROUPME_BOT_ID_ERROR_NOTIFY` to let us know that there may be an authorization issue. For our production deployment, this will likely be the staging bot to the staging GroupMe. Sending a message via the staging bot does not require the (usually invalid) user token.

To allow for quicker debugging and to prevent potential security vulnerabilities associated with logging secrets to the log, this PR also removes several log statements that were logging GroupMe request URLs that included secrets.

Tests have been updated accordingly.