### PR TITLE
fix: add invalid token alerting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -825,15 +825,6 @@
 				"node": ">=16"
 			}
 		},
-		"node_modules/@cloudflare/workers-types": {
-			"version": "4.20250823.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20250823.0.tgz",
-			"integrity": "sha512-z5pCggF3jG//h083+GEWCyQLW0A5GHq20akG+jN6ChyHQi/yZj1FcQcMhnvbBY4PiGq+SBiEj/LClG/lDPm+jg==",
-			"dev": true,
-			"license": "MIT OR Apache-2.0",
-			"optional": true,
-			"peer": true
-		},
 		"node_modules/@cspotcode/source-map-support": {
 			"version": "0.8.1",
 			"resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",

--- a/src/webhook-handler.ts
+++ b/src/webhook-handler.ts
@@ -11,19 +11,42 @@ export function isIllegalMessage(message: string): boolean {
 	);
 }
 
-async function safeFetch(url: string, options?: RequestInit, label?: string) {
+async function safeFetch(
+	url: string,
+	options?: RequestInit,
+	label?: string,
+	error_alerts_token?: string,
+) {
 	try {
 		const res = await fetch(url, options);
 		const text = await res.text();
-		if (!res.ok) throw new Error(`HTTP ${res.status} - ${text}`);
+		if (!res.ok) {
+			if (error_alerts_token) {
+				await postMessage(
+					error_alerts_token,
+					"⚠️ Error occurred in production! Check access token validity in CF environment variables.",
+				);
+			}
+			throw new Error(`HTTP ${res.status} - ${text}`);
+		}
 		return { res, text };
 	} catch (err) {
+		if (error_alerts_token) {
+			await postMessage(
+				error_alerts_token,
+				"⚠️ Error occurred in production! Check access token validity in CF environment variables.",
+			);
+		}
 		console.error(`[HTTP] Error${label ? ` - ${label}` : ""}:`, err);
 		throw err;
 	}
 }
 
-async function postMessage(bot_id: string, text: string) {
+async function postMessage(
+	bot_id: string,
+	text: string,
+	error_alerts_token?: string,
+) {
 	await safeFetch(
 		`https://api.groupme.com/v3/bots/post`,
 		{
@@ -31,14 +54,20 @@ async function postMessage(bot_id: string, text: string) {
 			body: JSON.stringify({ bot_id, text }),
 		},
 		"Post Bot Message",
+		error_alerts_token,
 	);
 }
 
-async function getGroupData(token: string, group_id: string) {
+async function getGroupData(
+	token: string,
+	group_id: string,
+	error_alerts_token?: string,
+) {
 	const { text: groupRaw } = await safeFetch(
 		`https://api.groupme.com/v3/groups/${group_id}?token=${token}`,
 		undefined,
 		"Get Group Data",
+		error_alerts_token,
 	);
 	return JSON.parse(groupRaw);
 }
@@ -47,11 +76,13 @@ async function deleteMessage(
 	token: string,
 	group_id: string,
 	message_id: string,
+	error_alerts_token?: string,
 ) {
 	await safeFetch(
 		`https://api.groupme.com/v3/conversations/${group_id}/messages/${message_id}?token=${token}`,
 		{ method: "DELETE" },
 		"Delete Message",
+		error_alerts_token,
 	);
 }
 
@@ -59,11 +90,13 @@ async function removeUser(
 	token: string,
 	group_id: string,
 	membership_id: string,
+	error_alerts_token?: string,
 ) {
 	await safeFetch(
 		`https://api.groupme.com/v3/groups/${group_id}/members/${membership_id}/remove?token=${token}`,
 		{ method: "POST" },
 		"Remove User",
+		error_alerts_token,
 	);
 }
 
@@ -86,15 +119,16 @@ export async function groupMeWebhookHandler(c: Context) {
 
 		const token = c.env.GROUPME_ACCESS_TOKEN;
 		const bot_id = c.env.GROUPME_BOT_ID;
+		const error_alerts_token = c.env.GROUPME_BOT_ID_ERROR_ALERTS;
 
 		// Staging instance will not remove users, only flag the message
 		if (staging) {
-			await postMessage(bot_id, "BOTS BEGONE 🤬");
+			await postMessage(bot_id, "BOTS BEGONE 🤬", error_alerts_token);
 			return;
 		}
 
 		try {
-			const groupData = await getGroupData(token, group_id);
+			const groupData = await getGroupData(token, group_id, error_alerts_token);
 
 			type GroupMember = { user_id: string; id: string };
 			const member = groupData.response.members.find(
@@ -106,17 +140,17 @@ export async function groupMeWebhookHandler(c: Context) {
 			}
 			const membership_id = member.id;
 
-			await deleteMessage(token, group_id, message_id);
-			await removeUser(token, group_id, membership_id);
+			await deleteMessage(token, group_id, message_id, error_alerts_token);
+			await removeUser(token, group_id, membership_id, error_alerts_token);
 
 			if (Math.floor(Math.random() * 1000000) === 462926) {
-				await postMessage(bot_id, "BOTS BEGONE 🤬");
+				await postMessage(bot_id, "BOTS BEGONE 🤬", error_alerts_token);
 			}
 		} catch (err) {
 			console.warn("General error handling blocked content", err);
-			if (c.env.GROUPME_BOT_ID_ERROR_ALERTS) {
+			if (error_alerts_token) {
 				await postMessage(
-					c.env.GROUPME_BOT_ID_ERROR_ALERTS,
+					error_alerts_token,
 					"⚠️ Error occurred in production! Check access token validity in CF environment variables.",
 				);
 			}

--- a/test/webhook-handler.test.ts
+++ b/test/webhook-handler.test.ts
@@ -504,8 +504,8 @@ describe("groupMeWebhookHandler", () => {
 	});
 
 	describe("safeFetch error handling", () => {
-		test("should send alert when safeFetch fails", async () => {
-			mockConsoleWarn.mockClear();
+		test("should send error alert when safeFetch fails and error alert bot ID is specified", async () => {
+			mockConsoleError.mockClear();
 			mockConsoleLog.mockClear();
 
 			if (mockContext.env) {
@@ -526,23 +526,31 @@ describe("groupMeWebhookHandler", () => {
 				status: 200,
 				text: async () => JSON.stringify({ success: true }),
 			} as Response);
+			mockFetch.mockResolvedValueOnce({
+				ok: true,
+				status: 200,
+				text: async () => JSON.stringify({ success: true }),
+			} as Response);
 
 			await expect(
 				groupMeWebhookHandler(mockContext as Context),
 			).rejects.toThrow("Network error");
 
-			expect(mockConsoleWarn).toHaveBeenCalledWith(
-				expect.stringMatching(/General error handling blocked content/),
-				expect.anything(),
+			expect(mockConsoleError).toHaveBeenCalledWith(
+				"[HTTP] Error - Get Group Data:",
+				expect.any(Error),
 			);
 
-			expect(mockFetch).toHaveBeenCalled();
+			expect(mockFetch).toHaveBeenCalledTimes(3);
 			expect(mockFetch).toHaveBeenNthCalledWith(
 				2,
 				"https://api.groupme.com/v3/bots/post",
 				expect.objectContaining({
 					method: "POST",
-					body: expect.stringContaining('"bot_id":"error_bot_id"'),
+					body: JSON.stringify({
+						bot_id: "error_bot_id",
+						text: "⚠️ Error occurred in production! Check access token validity in CF environment variables.",
+					}),
 				}),
 			);
 		});


### PR DESCRIPTION
The existing behavior for invalid token alerting did not properly send an alert message. By directly catching a thrown error in safeFetch, the alert message is sent on fetch failure.

Fixes #78 